### PR TITLE
encodeURI on cssPath to account for spaces

### DIFF
--- a/workflows/agenda/src/scripts/upcoming/generate.js
+++ b/workflows/agenda/src/scripts/upcoming/generate.js
@@ -5,7 +5,8 @@ function run(argv) {
 
 	const items = argv[0]
 	const mode = argv[1]
-	const cssPath = $.getenv('alfred_preferences') + "/workflows/" + $.getenv('alfred_workflow_uid') + '/'
+	// account for potential spaces in path (e.g, "Application Support" dir in path)
+	const cssPath = encodeURI($.getenv('alfred_preferences') + "/workflows/" + $.getenv('alfred_workflow_uid') + '/')
 
 	let html = app.doShellScript('cat ./scripts/upcoming/template/_template.html');
 	html = html.replace('{{ mode }}', mode).replace('{{ items }}', items).replace('{{ cssPath }}', cssPath)


### PR DESCRIPTION
Hey! First of all, thanks for this workflow, found it super useful 😁 

I noticed this morning when opening the generated overview page, if your Alfred preferences path has a space in it (e.g., the default prefs location is under `Application Support` within your home dir) then the CSS href can end up broken.

Example from browser inspect:

![image](https://user-images.githubusercontent.com/4218095/150121205-7f789e38-b763-4b6e-8f16-71ed002452ff.png)

This change adds `encodeURI` around the cssPath generation to handle that situation!